### PR TITLE
Undefined name: searching_all_files() --> cls.searching_all_files()

### DIFF
--- a/container/bert/predictor.py
+++ b/container/bert/predictor.py
@@ -93,7 +93,7 @@ class ScoringService(object):
             if x.is_file():
                 file_list.append(str(x))
             else:
-                file_list.append(searching_all_files(x))
+                file_list.append(cls.searching_all_files(x))
 
         return file_list
 
@@ -139,4 +139,3 @@ def transformation():
     result = json.dumps(predictions[:10])
 
     return flask.Response(response=result, status=200, mimetype='application/json')
-


### PR DESCRIPTION
Need to add __cls.__ to make the recursive call.

[flake8](http://flake8.pycqa.org) testing of https://github.com/kaushaltrivedi/fast-bert on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./container/bert/predictor.py:96:34: F821 undefined name 'searching_all_files'
                file_list.append(searching_all_files(x))
                                 ^
./fast_bert/lm-data.py:326:27: F821 undefined name 'random_word'
    t1_random, t1_label = random_word(tokens_a, tokenizer)
                          ^
./fast_bert/lm-data.py:327:27: F821 undefined name 'random_word'
    t2_random, t2_label = random_word(tokens_b, tokenizer)
                          ^
./fast_bert/data.py:84:13: F821 undefined name 'self'
            self._truncate_seq_pair(tokens_a, tokens_b, max_seq_length - 3)
            ^
4     F821 undefined name 'searching_all_files'
4
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree