### PR TITLE
Undefined name: 'self' used outside of any class

### DIFF
--- a/fast_bert/data.py
+++ b/fast_bert/data.py
@@ -45,7 +45,7 @@ class InputFeatures(object):
         self.label_id = label_id
 
 
-def _truncate_seq_pair(self, tokens_a, tokens_b, max_length):
+def _truncate_seq_pair(tokens_a, tokens_b, max_length):
     """Truncates a sequence pair in place to the maximum length."""
 
     # This is a simple heuristic which will always truncate the longer sequence
@@ -81,7 +81,7 @@ def convert_examples_to_features(examples, label_list, max_seq_length, tokenizer
             # Modifies `tokens_a` and `tokens_b` in place so that the total
             # length is less than the specified length.
             # Account for [CLS], [SEP], [SEP] with "- 3"
-            self._truncate_seq_pair(tokens_a, tokens_b, max_seq_length - 3)
+            _truncate_seq_pair(tokens_a, tokens_b, max_seq_length - 3)
         else:
             # Account for [CLS] and [SEP] with "- 2"
             if len(tokens_a) > max_seq_length - 2:


### PR DESCRIPTION
This looks like a refactoring error...

[flake8](http://flake8.pycqa.org) testing of https://github.com/kaushaltrivedi/fast-bert on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./container/bert/predictor.py:96:34: F821 undefined name 'searching_all_files'
                file_list.append(searching_all_files(x))
                                 ^
./fast_bert/lm-data.py:326:27: F821 undefined name 'random_word'
    t1_random, t1_label = random_word(tokens_a, tokenizer)
                          ^
./fast_bert/lm-data.py:327:27: F821 undefined name 'random_word'
    t2_random, t2_label = random_word(tokens_b, tokenizer)
                          ^
./fast_bert/data.py:84:13: F821 undefined name 'self'
            self._truncate_seq_pair(tokens_a, tokens_b, max_seq_length - 3)
            ^
4     F821 undefined name 'searching_all_files'
4
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree