### PR TITLE
Bump pytorch-pretrained-bert requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(name='fast_bert',
       packages=find_packages(exclude=["*.tests", "*.tests.*",
                                       "tests.*", "tests"]),
       install_requires=[
-          'pytorch-pretrained-bert',
+          'pytorch-pretrained-bert>=0.6.2',
           'fastai'
       ],
       classifiers=[


### PR DESCRIPTION
Fix #21 and other such potential issues by imposing an updated version of [pytorch-pretrained-BERT](https://github.com/huggingface/pytorch-pretrained-BERT)