### PR TITLE
Changed get_dataset_from_examples function for test set_type

### DIFF
--- a/fast_bert/data_cls.py
+++ b/fast_bert/data_cls.py
@@ -426,7 +426,7 @@ class BertDataBunch(object):
         elif set_type == 'dev':
             file_name = self.val_file
         elif set_type == 'test':
-            file_name = self.test_data
+            file_name = 'test.csv'
         
         cached_features_file = os.path.join(self.cache_dir, 'cached_{}_{}_{}_{}_{}'.format(
             self.model_type,


### PR DESCRIPTION
Changed **get_dataset_from_examples** function for _test_ **set_type** to fix the following error:
**TypeError: expected str, bytes or os.PathLike object, not NoneType**
This error is encountered whenever function **predict_batch** is called or when a **BertDataBunch** object is created with **test_data** assigned with a valid value.