### PR TITLE
Camembert fix

### DIFF
--- a/fast_bert/data_cls.py
+++ b/fast_bert/data_cls.py
@@ -41,16 +41,8 @@ MODEL_CLASSES = {
     "xlm": (XLMConfig, XLMForSequenceClassification, XLMTokenizer),
     "roberta": (RobertaConfig, RobertaForSequenceClassification, RobertaTokenizer),
     "albert": (AlbertConfig, AlbertForSequenceClassification, AlbertTokenizer),
-    "distilbert": (
-        DistilBertConfig,
-        DistilBertForSequenceClassification,
-        DistilBertTokenizer,
-    ),
-    "camembert": (
-        CamembertConfig,
-        CamembertForSequenceClassification,
-        CamembertTokenizer,
-    ),
+    "distilbert": (DistilBertConfig, DistilBertForSequenceClassification, DistilBertTokenizer),
+    "camembert-base": (CamembertConfig, CamembertForSequenceClassification, CamembertTokenizer)
 }
 
 

--- a/fast_bert/data_lm.py
+++ b/fast_bert/data_lm.py
@@ -40,6 +40,9 @@ from transformers import (
     DistilBertConfig,
     DistilBertForSequenceClassification,
     DistilBertTokenizer,
+    CamembertConfig,
+    CamembertForSequenceClassification,
+    CamembertTokenizer
 )
 
 MODEL_CLASSES = {
@@ -47,11 +50,8 @@ MODEL_CLASSES = {
     "xlnet": (XLNetConfig, XLNetForSequenceClassification, XLNetTokenizer),
     "xlm": (XLMConfig, XLMForSequenceClassification, XLMTokenizer),
     "roberta": (RobertaConfig, RobertaForSequenceClassification, RobertaTokenizer),
-    "distilbert": (
-        DistilBertConfig,
-        DistilBertForSequenceClassification,
-        DistilBertTokenizer,
-    ),
+    "distilbert": (DistilBertConfig, DistilBertForSequenceClassification, DistilBertTokenizer),
+    "camembert-base": (CamembertConfig, CamembertForSequenceClassification, CamembertTokenizer)
 }
 
 # Create text corpus suitable for language model training
@@ -59,7 +59,7 @@ MODEL_CLASSES = {
 
 def create_corpus(text_list, target_path, logger=None):
 
-    nlp = spacy.load("en_core_web_sm", disable=["tagger", "ner", "textcat"])
+#     nlp = spacy.load("en_core_web_sm", disable=["tagger", "ner", "textcat"])
 
     with open(target_path, "w") as f:
         #  Split sentences for each document

--- a/fast_bert/learner_cls.py
+++ b/fast_bert/learner_cls.py
@@ -86,7 +86,7 @@ MODEL_CLASSES = {
         (AlbertForSequenceClassification, AlbertForMultiLabelSequenceClassification),
         AlbertTokenizer,
     ),
-    "camembert": (
+    "camembert-base": (
         CamembertConfig,
         (
             CamembertForSequenceClassification,

--- a/fast_bert/learner_lm.py
+++ b/fast_bert/learner_lm.py
@@ -10,13 +10,14 @@ from .learner_util import Learner
 
 from .data_lm import BertLMDataBunch
 
-from transformers import (WEIGHTS_NAME, BertConfig, BertForMaskedLM, RobertaConfig, RobertaForMaskedLM, DistilBertConfig, DistilBertForMaskedLM)
+from transformers import (WEIGHTS_NAME, BertConfig, BertForMaskedLM, RobertaConfig, RobertaForMaskedLM, DistilBertConfig, DistilBertForMaskedLM, CamembertConfig, CamembertForMaskedLM)
 
 
 MODEL_CLASSES = {
     'bert': (BertConfig, BertForMaskedLM),
     'roberta': (RobertaConfig, RobertaForMaskedLM),
-    'distilbert': (DistilBertConfig, DistilBertForMaskedLM)
+    'distilbert': (DistilBertConfig, DistilBertForMaskedLM),
+    'camembert-base': (CamembertConfig, CamembertForMaskedLM)
 }
 
 class BertLMLearner(Learner):

--- a/fast_bert/prediction.py
+++ b/fast_bert/prediction.py
@@ -76,7 +76,7 @@ MODEL_CLASSES = {
         (AlbertForSequenceClassification, AlbertForMultiLabelSequenceClassification),
         AlbertTokenizer,
     ),
-    "camembert": (
+    "camembert-base": (
         CamembertConfig,
         (
             CamembertForSequenceClassification,


### PR DESCRIPTION
Could you merge this fix for camembert model please? I found the problem with dictionary key "camembert". In the transformers they use "camembert-base". Check:

from transformers import CamembertForSequenceClassification
CamembertForSequenceClassification.pretrained_model_archive_map.keys()