### PR TITLE
Explicitly cast TextProcessor examples to string

### DIFF
--- a/fast_bert/data_cls.py
+++ b/fast_bert/data_cls.py
@@ -312,7 +312,7 @@ class TextProcessor(DataProcessor):
             return list(
                 df.apply(
                     lambda row: InputExample(
-                        guid=row.index, text_a=row[text_col], label=None
+                        guid=row.index, text_a=str(row[text_col]), label=None
                     ),
                     axis=1,
                 )
@@ -321,7 +321,7 @@ class TextProcessor(DataProcessor):
             return list(
                 df.apply(
                     lambda row: InputExample(
-                        guid=row.index, text_a=row[text_col], label=str(row[label_col])
+                        guid=row.index, text_a=str(row[text_col]), label=str(row[label_col])
                     ),
                     axis=1,
                 )


### PR DESCRIPTION
When training on SageMaker, the input examples aren't cast to string causing TypeError: expected string or bytes-like object (see issue #158 ).

This pull request explicitly casts input text to string for single-label classification (although the problem likely also exists for multi-label as they aren't explicitly cast there either).