### PR TITLE
Changed PATH from posix to string in predictor.py

### DIFF
--- a/container/bert/predictor.py
+++ b/container/bert/predictor.py
@@ -29,7 +29,7 @@ PRETRAINED_PATH = Path(os.path.join(prefix, "code"))
 BERT_PRETRAINED_PATH = (
     PRETRAINED_PATH / "pretrained-weights" / "uncased_L-12_H-768_A-12/"
 )
-MODEL_PATH = PATH / "pytorch_model.bin"
+MODEL_PATH = PATH + "pytorch_model.bin"
 
 # request_text = None
 
@@ -43,11 +43,11 @@ class ScoringService(object):
         # print(cls.searching_all_files(PATH))
         # Get model predictor
         if cls.model == None:
-            with open(PATH / "model_config.json") as f:
+            with open(PATH + "model_config.json") as f:
                 model_config = json.load(f)
 
             predictor = BertClassificationPredictor(
-                PATH / "model_out",
+                PATH + "model_out",
                 label_path=PATH,
                 multi_label=bool(model_config["multi_label"]),
                 model_type=model_config["model_type"],

--- a/container/bert/predictor.py
+++ b/container/bert/predictor.py
@@ -22,14 +22,14 @@ warnings.filterwarnings("ignore", message="numpy.ufunc size changed")
 prefix = "/opt/ml/"
 
 # PATH = Path(os.path.join(prefix, "model"))
-PATH = prefix + "model"
+PATH = os.path.join(prefix, "model")
 
 PRETRAINED_PATH = Path(os.path.join(prefix, "code"))
 
 BERT_PRETRAINED_PATH = (
     PRETRAINED_PATH / "pretrained-weights" / "uncased_L-12_H-768_A-12/"
 )
-MODEL_PATH = PATH + "pytorch_model.bin"
+MODEL_PATH = os.path.join(PATH, "pytorch_model.bin")
 
 # request_text = None
 
@@ -43,11 +43,11 @@ class ScoringService(object):
         # print(cls.searching_all_files(PATH))
         # Get model predictor
         if cls.model == None:
-            with open(PATH + "model_config.json") as f:
+            with open(os.path.join(PATH, "model_config.json")) as f:
                 model_config = json.load(f)
 
             predictor = BertClassificationPredictor(
-                PATH + "model_out",
+                os.path.join(PATH, "model_out"),
                 label_path=PATH,
                 multi_label=bool(model_config["multi_label"]),
                 model_type=model_config["model_type"],

--- a/container/bert/predictor.py
+++ b/container/bert/predictor.py
@@ -21,7 +21,8 @@ warnings.filterwarnings("ignore", message="numpy.ufunc size changed")
 
 prefix = "/opt/ml/"
 
-PATH = Path(os.path.join(prefix, "model"))
+# PATH = Path(os.path.join(prefix, "model"))
+PATH = prefix + "model"
 
 PRETRAINED_PATH = Path(os.path.join(prefix, "code"))
 


### PR DESCRIPTION
This should fix the failures of SageMaker endpoint creation and BertClassificationPredictor instance creation.