### PR TITLE
switched indexing of non-masked tokens

### DIFF
--- a/fast_bert/data_lm.py
+++ b/fast_bert/data_lm.py
@@ -319,7 +319,7 @@ class BertLMDataBunch(object):
         masked_indices[:, 0] = False
         masked_indices[:, -1] = False
 
-        labels[~masked_indices] = -1  # We only compute loss on masked tokens
+        labels[~masked_indices] = -100  # We only compute loss on masked tokens
 
         # 80% of the time, we replace masked input tokens with tokenizer.mask_token ([MASK])
         indices_replaced = (


### PR DESCRIPTION
Current LM Finetuning code is incompatible with the latest version of transformers.

Fix for: https://github.com/kaushaltrivedi/fast-bert/issues/179