### PR TITLE
Fixed a missing label (formatting error)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ neg
 
 For multi-label classification, **labels.csv** will contain all possible labels:
 
-```toxic
+```
+toxic
 severe_toxic
 obscene
 threat


### PR DESCRIPTION
The "toxic" label was missing since it was in on the same line with the ``` code block start