### PR TITLE
Fix requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,4 @@ tokenizers==0.8.1.rc1
 transformers>=3.0.2
 pandas
 python-box
-itertools
-more_itertools
+more-itertools


### PR DESCRIPTION
Maybe someone should double-check the use-cases, but on python 3.8.5 itertools is integrated, so pip complains about it.
Also more_itertools is installed via the `more-itertools` package.